### PR TITLE
同一メッセージ内でのトークンの重複学習を防ぎ、スパムngramをスキップするロジックを追加hance

### DIFF
--- a/src/libs/wordcloud_service.py
+++ b/src/libs/wordcloud_service.py
@@ -126,7 +126,8 @@ def learn_from_text(db, text: str) -> None:
     token_entries = extract_tokens_with_indices(text)
     tokens = [word for word, _ in token_entries]
 
-    for token in tokens:
+    # 同一メッセージ内での繰り返しスパムを抑制するため、1トークンにつき1回だけ学習する。
+    for token in set(tokens):
         save_unigram(db, token)
 
     for ngram_size in (2, 3):
@@ -134,11 +135,18 @@ def learn_from_text(db, text: str) -> None:
             window = token_entries[index : index + ngram_size]
 
             # Keep only truly adjacent tokens in original text.
-            if all(
+            if not all(
                 window[pos + 1][1] - window[pos][1] == 1
                 for pos in range(len(window) - 1)
             ):
-                save_ngram(db, tuple(word for word, _ in window))
+                continue
+
+            # 同じ単語が繰り返されるスパムngramはスキップ。
+            ngram_words = [word for word, _ in window]
+            if len(set(ngram_words)) < len(ngram_words):
+                continue
+
+            save_ngram(db, tuple(ngram_words))
 
 
 def _compute_bigram_pmi(db, left_word: str, right_word: str, total: int) -> float | None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Unigram学習において、メッセージ内の重複トークンが適切に除去されるようになりました。
  * N-gram処理の精度が向上し、連続した隣接トークンのみが保存され、重複単語を含むN-gramはスキップされるようになりました。
  * 言語データの処理品質が全般的に改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->